### PR TITLE
Fetch external resources through HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <html>
   <head>
     <title>Interactive Hiera Demo</title>
-    <link rel="stylesheet" href="http:///code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+    <link rel="stylesheet" href="https:///code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
     <link rel="stylesheet" href="atelier-cave-light.css">
     <link rel="stylesheet" type="text/css" href="styles.css">
 
-    <script src="http://code.jquery.com/jquery-1.10.2.js"></script>
-    <script src="http://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+    <script src="https://code.jquery.com/jquery-1.10.2.js"></script>
+    <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
 
     <script src="highlight.pack.js"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <html>
   <head>
     <title>Interactive Hiera Demo</title>
-    <link rel="stylesheet" href="https:///code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
     <link rel="stylesheet" href="atelier-cave-light.css">
     <link rel="stylesheet" type="text/css" href="styles.css">
 
-    <script src="https://code.jquery.com/jquery-1.10.2.js"></script>
-    <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+    <script src="//code.jquery.com/jquery-1.10.2.js"></script>
+    <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
 
     <script src="highlight.pack.js"></script>
     <script>


### PR DESCRIPTION
Modern web browsers will refuse to load active content through HTTP from
an HTTPS served page.

This unbreaks https://puppetlabs.github.io/hierademo/ when using a recent browser.